### PR TITLE
Implement GPT-2 style transformer crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "gpt2-rs"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+libc = "0.2"
+
+[profile.release]
+opt-level = 3
+lto = true
+codegen-units = 1

--- a/README.md
+++ b/README.md
@@ -1,0 +1,39 @@
+# gpt2-rs
+
+A compact, pure Rust implementation of a GPT-2 style transformer intended for
+experimentation and education.  The project mirrors the layout of the original C
+code base the user provided while embracing idiomatic Rust constructs such as
+modules, structs and unit tests.
+
+## Features
+
+- Deterministic weight initialisation through a tiny xorshift PRNG.
+- Naïve but easy to follow implementations of multi-head self-attention,
+  layer-normalisation and the feed-forward network.
+- Minimal command line application that generates new text given a prompt.
+- Unit tests covering the most important tensor operations and model utilities.
+
+## Running the example
+
+```
+cargo run --release -- "Rust is"
+```
+
+Use `--steps <n>` to control how many tokens should be generated in addition to
+the provided prompt.
+
+## Project layout
+
+```
+├── Cargo.toml        # crate metadata
+├── src
+│   ├── layers.rs     # individual building blocks (attention, MLP, ...)
+│   ├── loader.rs     # deterministic initialisation helpers
+│   ├── model.rs      # high level GPT-2 inspired model
+│   └── main.rs       # command line entry point
+└── README.md
+```
+
+The implementation purposefully keeps the mathematics explicit which makes it
+a good starting point for experimenting with alternative architectures or
+sampling strategies without having to depend on external libraries.

--- a/src/layers.rs
+++ b/src/layers.rs
@@ -1,0 +1,237 @@
+//! Core building blocks used by the GPT-2 style model.
+//!
+//! The implementation favours clarity over raw performance.  The tensor
+//! operations are written in straight-forward Rust without any unsafe math or
+//! external dependencies which makes the code easy to inspect and extend.
+
+use std::f32;
+
+fn softmax(values: &mut [f32]) {
+    let max = values.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
+    let mut sum = 0.0;
+    for value in values.iter_mut() {
+        *value = (*value - max).exp();
+        sum += *value;
+    }
+    if sum == 0.0 {
+        return;
+    }
+    let inv_sum = 1.0 / sum;
+    for value in values.iter_mut() {
+        *value *= inv_sum;
+    }
+}
+
+#[derive(Clone)]
+pub struct Linear {
+    pub weight: Vec<f32>,
+    pub bias: Vec<f32>,
+    pub in_features: usize,
+    pub out_features: usize,
+}
+
+impl Linear {
+    pub fn new(in_features: usize, out_features: usize, weight: Vec<f32>, bias: Vec<f32>) -> Self {
+        assert_eq!(weight.len(), in_features * out_features);
+        assert_eq!(bias.len(), out_features);
+        Self {
+            weight,
+            bias,
+            in_features,
+            out_features,
+        }
+    }
+
+    pub fn forward(&self, input: &[f32], seq_len: usize) -> Vec<f32> {
+        assert_eq!(input.len(), seq_len * self.in_features);
+        let mut output = vec![0.0; seq_len * self.out_features];
+        for token in 0..seq_len {
+            let input_offset = token * self.in_features;
+            let output_offset = token * self.out_features;
+            let input_slice = &input[input_offset..input_offset + self.in_features];
+            let output_slice = &mut output[output_offset..output_offset + self.out_features];
+            for out_idx in 0..self.out_features {
+                let mut acc = self.bias[out_idx];
+                let weight_offset = out_idx * self.in_features;
+                for in_idx in 0..self.in_features {
+                    acc += self.weight[weight_offset + in_idx] * input_slice[in_idx];
+                }
+                output_slice[out_idx] = acc;
+            }
+        }
+        output
+    }
+}
+
+#[derive(Clone)]
+pub struct LayerNorm {
+    pub gamma: Vec<f32>,
+    pub beta: Vec<f32>,
+    pub epsilon: f32,
+}
+
+impl LayerNorm {
+    pub fn new(hidden_size: usize, gamma: Vec<f32>, beta: Vec<f32>, epsilon: f32) -> Self {
+        assert_eq!(gamma.len(), hidden_size);
+        assert_eq!(beta.len(), hidden_size);
+        Self {
+            gamma,
+            beta,
+            epsilon,
+        }
+    }
+
+    pub fn forward(&self, values: &mut [f32], seq_len: usize, hidden_size: usize) {
+        assert_eq!(values.len(), seq_len * hidden_size);
+        for token in 0..seq_len {
+            let offset = token * hidden_size;
+            let slice = &mut values[offset..offset + hidden_size];
+            let mut mean = 0.0;
+            for &value in slice.iter() {
+                mean += value;
+            }
+            mean /= hidden_size as f32;
+
+            let mut variance = 0.0;
+            for &value in slice.iter() {
+                let diff = value - mean;
+                variance += diff * diff;
+            }
+            variance /= hidden_size as f32;
+            let denom = (variance + self.epsilon).sqrt();
+
+            for (idx, value) in slice.iter_mut().enumerate() {
+                let normalized = (*value - mean) / denom;
+                *value = normalized * self.gamma[idx] + self.beta[idx];
+            }
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct MultiHeadAttention {
+    w_q: Linear,
+    w_k: Linear,
+    w_v: Linear,
+    w_o: Linear,
+    n_heads: usize,
+    head_dim: usize,
+    hidden_size: usize,
+    scale: f32,
+}
+
+impl MultiHeadAttention {
+    pub fn new(
+        hidden_size: usize,
+        n_heads: usize,
+        w_q: Linear,
+        w_k: Linear,
+        w_v: Linear,
+        w_o: Linear,
+    ) -> Self {
+        assert_eq!(
+            hidden_size % n_heads,
+            0,
+            "hidden size must be divisible by number of heads"
+        );
+        let head_dim = hidden_size / n_heads;
+        Self {
+            w_q,
+            w_k,
+            w_v,
+            w_o,
+            n_heads,
+            head_dim,
+            hidden_size,
+            scale: 1.0 / (head_dim as f32).sqrt(),
+        }
+    }
+
+    pub fn hidden_size(&self) -> usize {
+        self.hidden_size
+    }
+
+    pub fn forward(&self, hidden_states: &[f32], seq_len: usize) -> Vec<f32> {
+        assert_eq!(hidden_states.len(), seq_len * self.hidden_size);
+        if seq_len == 0 {
+            return Vec::new();
+        }
+        let query = self.w_q.forward(hidden_states, seq_len);
+        let key = self.w_k.forward(hidden_states, seq_len);
+        let value = self.w_v.forward(hidden_states, seq_len);
+        let mut combined = vec![0.0; seq_len * self.hidden_size];
+        let mut scores = vec![0.0; seq_len];
+
+        for token in 0..seq_len {
+            for head in 0..self.n_heads {
+                let head_offset = head * self.head_dim;
+                let query_offset = token * self.hidden_size + head_offset;
+                for past in 0..=token {
+                    let key_offset = past * self.hidden_size + head_offset;
+                    let mut dot = 0.0;
+                    for dim in 0..self.head_dim {
+                        dot += query[query_offset + dim] * key[key_offset + dim];
+                    }
+                    scores[past] = dot * self.scale;
+                }
+                softmax(&mut scores[..token + 1]);
+                for dim in 0..self.head_dim {
+                    let mut value_acc = 0.0;
+                    for past in 0..=token {
+                        let val_offset = past * self.hidden_size + head_offset;
+                        value_acc += scores[past] * value[val_offset + dim];
+                    }
+                    combined[query_offset + dim] = value_acc;
+                }
+                for past in 0..=token {
+                    scores[past] = 0.0;
+                }
+            }
+        }
+
+        self.w_o.forward(&combined, seq_len)
+    }
+}
+
+#[derive(Clone)]
+pub struct FeedForward {
+    proj_in: Linear,
+    proj_out: Linear,
+}
+
+impl FeedForward {
+    pub fn new(proj_in: Linear, proj_out: Linear) -> Self {
+        Self { proj_in, proj_out }
+    }
+
+    pub fn forward(&self, hidden_states: &[f32], seq_len: usize) -> Vec<f32> {
+        let intermediate = self.proj_in.forward(hidden_states, seq_len);
+        let activated: Vec<f32> = intermediate.into_iter().map(gelu).collect();
+        self.proj_out.forward(&activated, seq_len)
+    }
+}
+
+fn gelu(x: f32) -> f32 {
+    const COEFF: f32 = std::f32::consts::FRAC_2_SQRT_PI;
+    0.5 * x * (1.0 + (COEFF * (x + 0.044_715 * x.powi(3))).tanh())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn softmax_normalizes() {
+        let mut values = vec![1.0, 2.0, 3.0];
+        softmax(&mut values);
+        let sum: f32 = values.iter().sum();
+        assert!((sum - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn linear_forward_shape() {
+        let layer = Linear::new(2, 3, vec![1.0; 6], vec![0.0; 3]);
+        let out = layer.forward(&[1.0, 2.0, -1.0, 0.5], 2);
+        assert_eq!(out.len(), 6);
+    }
+}

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -1,0 +1,81 @@
+//! Deterministic weight initialisation utilities.
+//!
+//! The original C implementation that inspired this project exposed a manual
+//! initialisation routine.  In Rust we model that behaviour through the
+//! [`WeightInitializer`] type which feeds pseudo random numbers into the model
+//! layers.  Keeping the generator extremely small makes it simple to understand
+//! the values that end up in the network which is perfect for experimentation
+//! and educational purposes.
+
+use crate::layers::{FeedForward, LayerNorm, Linear, MultiHeadAttention};
+
+pub struct WeightInitializer {
+    state: u64,
+}
+
+impl WeightInitializer {
+    pub fn new(seed: u64) -> Self {
+        let state = if seed == 0 {
+            0x_4d595df4_d0f33173
+        } else {
+            seed
+        };
+        Self { state }
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        let mut x = self.state;
+        x ^= x << 7;
+        x ^= x >> 9;
+        x ^= x << 8;
+        self.state = x;
+        x
+    }
+
+    pub fn next_f32(&mut self) -> f32 {
+        let value = self.next_u64() as f64 / u64::MAX as f64;
+        (value * 2.0 - 1.0) as f32
+    }
+
+    pub fn vector(&mut self, len: usize, scale: f32) -> Vec<f32> {
+        let mut data = Vec::with_capacity(len);
+        for _ in 0..len {
+            data.push(self.next_f32() * scale);
+        }
+        data
+    }
+
+    pub fn embeddings(&mut self, rows: usize, cols: usize) -> Vec<f32> {
+        self.vector(rows * cols, 0.02)
+    }
+
+    pub fn linear(&mut self, in_features: usize, out_features: usize) -> Linear {
+        let scale = 1.0 / (in_features as f32).sqrt();
+        let weight = self.vector(in_features * out_features, scale);
+        let bias = vec![0.0; out_features];
+        Linear::new(in_features, out_features, weight, bias)
+    }
+
+    pub fn layer_norm(&mut self, hidden_size: usize) -> LayerNorm {
+        let mut gamma = vec![1.0; hidden_size];
+        for value in gamma.iter_mut() {
+            *value += self.next_f32() * 0.01;
+        }
+        let beta = vec![0.0; hidden_size];
+        LayerNorm::new(hidden_size, gamma, beta, 1e-5)
+    }
+
+    pub fn attention(&mut self, hidden_size: usize, n_heads: usize) -> MultiHeadAttention {
+        let w_q = self.linear(hidden_size, hidden_size);
+        let w_k = self.linear(hidden_size, hidden_size);
+        let w_v = self.linear(hidden_size, hidden_size);
+        let w_o = self.linear(hidden_size, hidden_size);
+        MultiHeadAttention::new(hidden_size, n_heads, w_q, w_k, w_v, w_o)
+    }
+
+    pub fn feed_forward(&mut self, hidden_size: usize, intermediate: usize) -> FeedForward {
+        let proj_in = self.linear(hidden_size, intermediate);
+        let proj_out = self.linear(intermediate, hidden_size);
+        FeedForward::new(proj_in, proj_out)
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,68 @@
+mod layers;
+mod loader;
+mod model;
+
+use libc::{clock_gettime, timespec, CLOCK_MONOTONIC};
+use model::{Gpt2Config, Gpt2Model};
+
+fn monotonic_time() -> timespec {
+    unsafe {
+        let mut ts = timespec {
+            tv_sec: 0,
+            tv_nsec: 0,
+        };
+        let result = clock_gettime(CLOCK_MONOTONIC, &mut ts);
+        if result != 0 {
+            panic!("clock_gettime failed: {}", std::io::Error::last_os_error());
+        }
+        ts
+    }
+}
+
+fn elapsed_ms(start: timespec, end: timespec) -> f64 {
+    let mut secs = end.tv_sec - start.tv_sec;
+    let mut nanos = end.tv_nsec - start.tv_nsec;
+    if nanos < 0 {
+        secs -= 1;
+        nanos += 1_000_000_000;
+    }
+    secs as f64 * 1_000.0 + nanos as f64 / 1_000_000.0
+}
+
+fn parse_args() -> (String, usize) {
+    let mut args = std::env::args().skip(1);
+    let mut steps = 32usize;
+    let mut prompt_parts = Vec::new();
+    while let Some(arg) = args.next() {
+        if arg == "--steps" {
+            if let Some(value) = args.next() {
+                if let Ok(parsed) = value.parse::<usize>() {
+                    steps = parsed;
+                }
+            }
+        } else {
+            prompt_parts.push(arg);
+        }
+    }
+    let prompt = if prompt_parts.is_empty() {
+        String::from("Hello, GPT-2!")
+    } else {
+        prompt_parts.join(" ")
+    };
+    (prompt, steps)
+}
+
+fn main() {
+    let (prompt, steps) = parse_args();
+    let config = Gpt2Config::small();
+    let model = Gpt2Model::initialise(config, 0x_cafebabedeadbeefu64);
+
+    let start = monotonic_time();
+    let generated = model.generate(&prompt, steps);
+    let end = monotonic_time();
+
+    println!("Prompt   : {}", prompt);
+    println!("Generated: {}", generated);
+    println!("Steps    : {}", steps);
+    println!("Duration : {:.3} ms", elapsed_ms(start, end));
+}

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,0 +1,203 @@
+//! High level GPT-2 style network implementation.
+//!
+//! The goal of this module is not to be a drop-in replacement for the original
+//! OpenAI model but to provide an approachable pure Rust implementation that can
+//! be inspected and experimented with.
+
+use crate::layers::{FeedForward, LayerNorm, Linear, MultiHeadAttention};
+use crate::loader::WeightInitializer;
+
+#[derive(Debug, Clone)]
+pub struct Gpt2Config {
+    pub vocab_size: usize,
+    pub n_positions: usize,
+    pub n_ctx: usize,
+    pub n_embd: usize,
+    pub n_layer: usize,
+    pub n_head: usize,
+}
+
+impl Default for Gpt2Config {
+    fn default() -> Self {
+        Self {
+            vocab_size: 256,
+            n_positions: 64,
+            n_ctx: 64,
+            n_embd: 128,
+            n_layer: 4,
+            n_head: 4,
+        }
+    }
+}
+
+impl Gpt2Config {
+    pub fn small() -> Self {
+        Self::default()
+    }
+}
+
+struct TransformerBlock {
+    attn_norm: LayerNorm,
+    attention: MultiHeadAttention,
+    mlp_norm: LayerNorm,
+    mlp: FeedForward,
+}
+
+impl TransformerBlock {
+    fn new(config: &Gpt2Config, init: &mut WeightInitializer) -> Self {
+        let attn_norm = init.layer_norm(config.n_embd);
+        let attention = init.attention(config.n_embd, config.n_head);
+        let mlp_norm = init.layer_norm(config.n_embd);
+        let mlp = init.feed_forward(config.n_embd, config.n_embd * 4);
+        Self {
+            attn_norm,
+            attention,
+            mlp_norm,
+            mlp,
+        }
+    }
+
+    fn forward(&self, hidden_states: &mut [f32], seq_len: usize) {
+        let hidden_size = self.attention.hidden_size();
+        let mut normed = hidden_states.to_vec();
+        self.attn_norm.forward(&mut normed, seq_len, hidden_size);
+        let attn_out = self.attention.forward(&normed, seq_len);
+        for (value, residual) in hidden_states.iter_mut().zip(attn_out.iter()) {
+            *value += residual;
+        }
+
+        let mut mlp_input = hidden_states.to_vec();
+        self.mlp_norm.forward(&mut mlp_input, seq_len, hidden_size);
+        let mlp_out = self.mlp.forward(&mlp_input, seq_len);
+        for (value, residual) in hidden_states.iter_mut().zip(mlp_out.iter()) {
+            *value += residual;
+        }
+    }
+}
+
+pub struct Gpt2Model {
+    pub config: Gpt2Config,
+    token_embedding: Vec<f32>,
+    position_embedding: Vec<f32>,
+    blocks: Vec<TransformerBlock>,
+    final_norm: LayerNorm,
+    lm_head: Linear,
+}
+
+impl Gpt2Model {
+    pub fn initialise(config: Gpt2Config, seed: u64) -> Self {
+        let mut init = WeightInitializer::new(seed);
+        let token_embedding = init.embeddings(config.vocab_size, config.n_embd);
+        let position_embedding = init.embeddings(config.n_positions, config.n_embd);
+        let mut blocks = Vec::with_capacity(config.n_layer);
+        for _ in 0..config.n_layer {
+            blocks.push(TransformerBlock::new(&config, &mut init));
+        }
+        let final_norm = init.layer_norm(config.n_embd);
+        let lm_head = init.linear(config.n_embd, config.vocab_size);
+        Self {
+            config,
+            token_embedding,
+            position_embedding,
+            blocks,
+            final_norm,
+            lm_head,
+        }
+    }
+
+    pub fn encode(&self, text: &str) -> Vec<usize> {
+        let vocab = self.config.vocab_size;
+        text.bytes().map(|b| (b as usize) % vocab).collect()
+    }
+
+    pub fn decode(&self, tokens: &[usize]) -> String {
+        tokens
+            .iter()
+            .map(|&id| {
+                let byte = (id % 256) as u8;
+                byte as char
+            })
+            .collect()
+    }
+
+    pub fn forward(&self, tokens: &[usize]) -> Vec<f32> {
+        if tokens.is_empty() {
+            return Vec::new();
+        }
+        let seq_len = tokens.len().min(self.config.n_ctx);
+        let hidden_size = self.config.n_embd;
+        let mut hidden_states = vec![0.0; seq_len * hidden_size];
+        for (position, &token_id) in tokens.iter().take(seq_len).enumerate() {
+            let token_index = token_id % self.config.vocab_size;
+            let pos_index = position % self.config.n_positions;
+            let embed_offset = token_index * hidden_size;
+            let pos_offset = pos_index * hidden_size;
+            let hidden_offset = position * hidden_size;
+            for dim in 0..hidden_size {
+                hidden_states[hidden_offset + dim] = self.token_embedding[embed_offset + dim]
+                    + self.position_embedding[pos_offset + dim];
+            }
+        }
+
+        for block in &self.blocks {
+            block.forward(&mut hidden_states, seq_len);
+        }
+
+        let mut normed = hidden_states.clone();
+        self.final_norm
+            .forward(&mut normed, seq_len, self.config.n_embd);
+        self.lm_head.forward(&normed, seq_len)
+    }
+
+    pub fn generate(&self, prompt: &str, steps: usize) -> String {
+        let mut tokens = self.encode(prompt);
+        if tokens.is_empty() {
+            tokens.push(b' ' as usize);
+        }
+        for _ in 0..steps {
+            let context_len = tokens.len().min(self.config.n_ctx);
+            let start = tokens.len().saturating_sub(context_len);
+            let context = &tokens[start..];
+            let logits = self.forward(context);
+            if logits.is_empty() {
+                break;
+            }
+            let vocab = self.config.vocab_size;
+            let last = &logits[(context_len - 1) * vocab..context_len * vocab];
+            let mut best_index = 0;
+            let mut best_score = f32::NEG_INFINITY;
+            for (idx, &score) in last.iter().enumerate() {
+                if score > best_score {
+                    best_score = score;
+                    best_index = idx;
+                }
+            }
+            tokens.push(best_index);
+        }
+        self.decode(&tokens)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encode_decode_roundtrip() {
+        let model = Gpt2Model::initialise(Gpt2Config::default(), 42);
+        let text = "Hello";
+        let tokens = model.encode(text);
+        let decoded = model.decode(&tokens);
+        assert_eq!(decoded, text);
+    }
+
+    #[test]
+    fn forward_respects_context_limit() {
+        let mut config = Gpt2Config::default();
+        config.n_ctx = 4;
+        let model = Gpt2Model::initialise(config, 123);
+        let tokens = vec![1, 2, 3, 4, 5, 6];
+        let logits = model.forward(&tokens);
+        assert_eq!(logits.len(), 4 * model.config.vocab_size);
+    }
+}


### PR DESCRIPTION
## Summary
- add linear, layer norm, attention and feed-forward layers implemented in pure Rust
- provide deterministic weight initialiser to build transformer blocks and embeddings
- wire everything together in a GPT-2 style model with a CLI example and updated documentation

## Testing
- cargo fmt
- cargo test *(fails: unable to download crates.io index due to 403 CONNECT tunnel failure)*

------
https://chatgpt.com/codex/tasks/task_e_68c86e8f55e4832682850e7cc7864dd6